### PR TITLE
Fix intersection being one way

### DIFF
--- a/intervals/__init__.py
+++ b/intervals/__init__.py
@@ -498,6 +498,8 @@ class AbstractInterval(object):
                 other.lower_inc if other.lower > self.lower else self.lower_inc
             )
             intersection.upper_inc = other.upper_inc
+        else:
+            return other & self
         return intersection
 
     def __or__(self, other):

--- a/tests/test_arithmetic.py
+++ b/tests/test_arithmetic.py
@@ -33,7 +33,9 @@ class TestArithmeticOperators(object):
     @mark.parametrize(('first', 'second', 'intersection'), (
         ('[1, 5]', '[2, 9]', '[2, 5]'),
         ('[3, 4]', '[3, 9]', '[3, 4]'),
-        ('(3, 6]', '[2, 6)', '(3, 6)')
+        ('(3, 6]', '[2, 6)', '(3, 6)'),
+        ('[1, 9]', '[2, 5]', '[2, 5]'),
+        ('[2, 5]', '[1, 9]', '[2, 5]'),
     ))
     def test_intersection(self, first, second, intersection):
         IntInterval(first) & IntInterval(second) == IntInterval(intersection)


### PR DESCRIPTION
Fast fix for

```
>>> Interval([-7, 7]) & Interval([-4, 1])
IntInterval('[-4, 1]')
>>> Interval([-4, 1]) & Interval([-7, 7])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "intervals/__init__.py", line 501, in __and__
    return intersection
UnboundLocalError: local variable 'intersection' referenced before assignment
```
