### PR TITLE
Remove dependency on six

### DIFF
--- a/intervals/interval.py
+++ b/intervals/interval.py
@@ -12,9 +12,12 @@ from decimal import Decimal
 import operator
 from infinity import inf, is_infinite
 from math import floor, ceil
-import six
 from .parser import IntervalParser
 from .exc import IntervalException, RangeBoundsException
+try:
+    string_types = basestring,  # Python 2
+except NameError:
+    string_types = str,  # Python 3
 
 
 def is_number(number):
@@ -178,7 +181,7 @@ class AbstractInterval(object):
             return value
         elif isinstance(value, self.type):
             return value
-        elif isinstance(value, six.string_types):
+        elif isinstance(value, string_types):
             return self.coerce_string(value)
         else:
             return self.coerce_obj(value)

--- a/intervals/parser.py
+++ b/intervals/parser.py
@@ -1,6 +1,9 @@
 from collections import Iterable
-import six
 from .exc import IntervalException
+try:
+    string_types = basestring,  # Python 2
+except NameError:
+    string_types = str,  # Python 3
 
 
 strip = lambda a: a.strip()
@@ -64,7 +67,7 @@ class IntervalParser(object):
         return lower, upper, True, True
 
     def __call__(self, bounds, lower_inc=None, upper_inc=None):
-        if isinstance(bounds, six.string_types):
+        if isinstance(bounds, string_types):
             values = self.parse_string(bounds)
         elif isinstance(bounds, Iterable):
             values = self.parse_sequence(bounds)

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
     dependency_links=[],
     install_requires=[
         'infinity>=0.1.3',
-        'six>=1.4.1',
     ],
     extras_require=extras_require,
     classifiers=[


### PR DESCRIPTION
Six was only used in a very few places, and only for its string_type.