### PR TITLE
Interval exception detect when modify the lower or the upper property on an exist interval instance

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/intervals/interval.py
+++ b/intervals/interval.py
@@ -40,9 +40,9 @@ def py2round(value):
     Python 3 also returns an int; Python 2 returns a float.
     """
     if value > 0:
-        return float(floor(float(value)+0.5))
+        return float(floor(float(value) + 0.5))
     else:
-        return float(ceil(float(value)-0.5))
+        return float(ceil(float(value) - 0.5))
 
 
 def canonicalize_lower(interval, inc=True):
@@ -86,11 +86,11 @@ def canonicalize(interval, lower_inc=True, upper_inc=False):
 def coerce_interval(func):
     def wrapper(self, arg):
         if (
-            isinstance(arg, list) or
-            isinstance(arg, tuple) or
-            isinstance(arg, self.type) or
-            isinstance(arg, type(self)) or
-            arg == inf or arg == -inf
+                isinstance(arg, list) or
+                isinstance(arg, tuple) or
+                isinstance(arg, self.type) or
+                isinstance(arg, type(self)) or
+                arg == inf or arg == -inf
         ):
             try:
                 if arg is not None:
@@ -103,6 +103,7 @@ def coerce_interval(func):
         except (ValueError, TypeError):
             pass
         return func(self, arg)
+
     return wrapper
 
 
@@ -112,11 +113,11 @@ class AbstractInterval(object):
     parser = IntervalParser()
 
     def __init__(
-        self,
-        bounds,
-        lower_inc=None,
-        upper_inc=None,
-        step=None
+            self,
+            bounds,
+            lower_inc=None,
+            upper_inc=None,
+            step=None
     ):
         """
         Parse given args and assign lower and upper bound for this number
@@ -184,15 +185,19 @@ class AbstractInterval(object):
             self.parser(bounds, lower_inc, upper_inc)
         )
 
-        if self.lower > self.upper:
+        self.range_init_and_setter_exception_detect(self.lower, self.upper, self.lower_inc, self.upper_inc)
+
+    @classmethod
+    def range_init_and_setter_exception_detect(cls, lower, upper, lower_inc, upper_inc):
+        if lower > upper:
             raise RangeBoundsException(
-                self.lower,
-                self.upper
+                lower,
+                upper
             )
         if (
-            self.lower == self.upper and
-            not self.lower_inc and
-            not self.upper_inc
+                lower == upper and
+                not lower_inc and
+                not upper_inc
         ):
             raise IllegalArgument(
                 'The bounds may be equal only if at least one of the bounds '
@@ -320,8 +325,13 @@ class AbstractInterval(object):
     def lower(self, value):
         value = self.coerce_value(value)
         if value is None:
+            if hasattr(self, 'upper_inc'):
+                self.range_init_and_setter_exception_detect(-inf, self.upper, self.lower_inc, self.upper_inc)
             self._lower = -inf
         else:
+            if hasattr(self, 'upper_inc'):
+                self.range_init_and_setter_exception_detect(self.round_value_by_step(value), self.upper, self.lower_inc,
+                                                            self.upper_inc)
             self._lower = self.round_value_by_step(value)
 
     @property
@@ -332,8 +342,13 @@ class AbstractInterval(object):
     def upper(self, value):
         value = self.coerce_value(value)
         if value is None:
+            if hasattr(self, 'upper_inc'):
+                self.range_init_and_setter_exception_detect(self.lower, inf, self.lower_inc, self.upper_inc)
             self._upper = inf
         else:
+            if hasattr(self, 'upper_inc'):
+                self.range_init_and_setter_exception_detect(self.lower, self.round_value_by_step(value), self.lower_inc,
+                                                            self.upper_inc)
             self._upper = self.round_value_by_step(value)
 
     def round_value_by_step(self, value):
@@ -385,11 +400,11 @@ class AbstractInterval(object):
 
     def equals(self, other):
         return (
-            self.lower == other.lower and
-            self.upper == other.upper and
-            self.lower_inc == other.lower_inc and
-            self.upper_inc == other.upper_inc and
-            self.type == other.type
+                self.lower == other.lower and
+                self.upper == other.upper and
+                self.lower_inc == other.lower_inc and
+                self.upper_inc == other.upper_inc and
+                self.type == other.type
         )
 
     @coerce_interval
@@ -443,8 +458,8 @@ class AbstractInterval(object):
             else operator.gt
         )
         return (
-            lower_op(self.lower, other.lower) and
-            upper_op(self.upper, other.upper)
+                lower_op(self.lower, other.lower) and
+                upper_op(self.upper, other.upper)
         )
 
     @property
@@ -476,12 +491,12 @@ class AbstractInterval(object):
     def empty(self):
         if self.discrete and not self.degenerate:
             return (
-                self.upper - self.lower == self.step
-                and not (self.upper_inc or self.lower_inc)
+                    self.upper - self.lower == self.step
+                    and not (self.upper_inc or self.lower_inc)
             )
         return (
-            self.upper == self.lower
-            and not (self.lower_inc and self.upper_inc)
+                self.upper == self.lower
+                and not (self.lower_inc and self.upper_inc)
         )
 
     def __bool__(self):
@@ -672,10 +687,10 @@ class AbstractInterval(object):
         * [1, 3) and (3, 5) are not connected
         """
         return self.upper > other.lower and other.upper > self.lower or (
-            self.upper == other.lower and (self.upper_inc or other.lower_inc)
+                self.upper == other.lower and (self.upper_inc or other.lower_inc)
         ) or (
-            self.lower == other.upper and (self.lower_inc or other.upper_inc)
-        )
+                       self.lower == other.upper and (self.lower_inc or other.upper_inc)
+               )
 
 
 class NumberInterval(AbstractInterval):
@@ -791,5 +806,6 @@ class IntervalFactory(object):
         raise IntervalException(
             'Could not initialize interval.'
         )
+
 
 Interval = IntervalFactory()

--- a/tests/interval/test_initialization.py
+++ b/tests/interval/test_initialization.py
@@ -20,18 +20,18 @@ class TestIntervalInit(object):
         with raises(TypeError) as e:
             FloatInterval('(0.2, 0.5)')
         assert (
-            'First argument should be a list or tuple. If you wish to '
-            'initialize an interval from string, use from_string factory '
-            'method.'
-        ) in str(e)
+                   'First argument should be a list or tuple. If you wish to '
+                   'initialize an interval from string, use from_string factory '
+                   'method.'
+               ) in str(e)
 
     def test_invalid_argument(self):
         with raises(IllegalArgument) as e:
             FloatInterval((0, 0))
         assert (
-            'The bounds may be equal only if at least one of the bounds is '
-            'closed.'
-        ) in str(e)
+                   'The bounds may be equal only if at least one of the bounds is '
+                   'closed.'
+               ) in str(e)
 
     def test_floats(self):
         interval = FloatInterval((0.2, 0.5))
@@ -155,11 +155,11 @@ class TestIntervalInit(object):
     @mark.parametrize(
         ('number_range', 'lower', 'upper'),
         (
-            ('-2-2', -2, 2),
-            ('-3--2', -3, -2),
-            ('2-3', 2, 3),
-            ('2-', 2, inf),
-            ('-5', -5, -5)
+                ('-2-2', -2, 2),
+                ('-3--2', -3, -2),
+                ('2-3', 2, 3),
+                ('2-', 2, inf),
+                ('-5', -5, -5)
         )
     )
     def test_hyphen_format(self, number_range, lower, upper):
@@ -170,18 +170,18 @@ class TestIntervalInit(object):
     @mark.parametrize(
         ('constructor', 'number_range'),
         (
-            (IntInterval, (3, 2)),
-            (IntInterval, [4, 2]),
-            (IntInterval, (float('inf'), 2)),
-            (CharacterInterval, ('c', 'b')),
-            (CharacterInterval, ('d', 'b')),
-            (CharacterInterval, (inf, 'b')),
+                (IntInterval, (3, 2)),
+                (IntInterval, [4, 2]),
+                (IntInterval, (float('inf'), 2)),
+                (CharacterInterval, ('c', 'b')),
+                (CharacterInterval, ('d', 'b')),
+                (CharacterInterval, (inf, 'b')),
         )
     )
     def test_raises_exception_for_badly_constructed_range(
-        self,
-        constructor,
-        number_range
+            self,
+            constructor,
+            number_range
     ):
         with raises(RangeBoundsException):
             constructor(number_range)
@@ -191,14 +191,58 @@ class TestTypeGuessing(object):
     @mark.parametrize(
         ('number_range', 'type'),
         (
-            ((2, 3), int),
-            ([-6, 8], int),
-            (8.5, float),
-            ([Decimal(2), 9], int),
-            ([Decimal('0.5'), 9], float),
-            ([date(2000, 1, 1), inf], date),
-            (('a', 'e'), str),
+                ((2, 3), int),
+                ([-6, 8], int),
+                (8.5, float),
+                ([Decimal(2), 9], int),
+                ([Decimal('0.5'), 9], float),
+                ([date(2000, 1, 1), inf], date),
+                (('a', 'e'), str),
         )
     )
     def test_guesses_types(self, number_range, type):
         assert Interval(number_range).type == type
+
+
+class TestIntervalChanging(object):
+    @mark.parametrize(
+        ('constructor', 'number_range', 'bad_lower'),
+        (
+                (IntInterval, (1, 2), 3),
+                (IntInterval, [1, 2], 3),
+                (IntInterval, (1, 2), float('inf')),
+                (CharacterInterval, ('a', 'b'), 'c'),
+                (CharacterInterval, ('a', 'b'), 'd'),
+                (CharacterInterval, ('a', 'b'), inf),
+        )
+    )
+    def test_raises_exception_for_badly_lower_changing(
+            self,
+            constructor,
+            number_range,
+            bad_lower
+    ):
+        with raises(RangeBoundsException):
+            interval = constructor(number_range)
+            interval.lower = bad_lower
+
+    @mark.parametrize(
+        ('constructor', 'number_range', 'bad_upper'),
+        (
+                (IntInterval, (1, 2), 0),
+                (IntInterval, [1, 2], 0),
+                (IntInterval, (1, 2), float('-inf')),
+                (CharacterInterval, ('b', 'c'), 'a'),
+                (CharacterInterval, ('b', 'd'), 'a'),
+                (CharacterInterval, ('b', 'c'), -inf),
+        )
+    )
+    def test_raises_exception_for_badly_upper_changing(
+            self,
+            constructor,
+            number_range,
+            bad_upper
+    ):
+        with raises(RangeBoundsException):
+            interval = constructor(number_range)
+            interval.upper = bad_upper


### PR DESCRIPTION
Fix the bug of range exception detection when change the lower or the upper property. Add 12 new tests in test_initialization.py named class TestIntervalChanging.

before fixing:
>>> interval = IntInterval([1, 2])
>>> interval
IntInterval('[1, 2]')
>>> interval.lower = 3
>>> interval
IntInterval('[3, 2]')

after fixing:
>>> interval = IntInterval([1, 2])
>>> interval
IntInterval('[1, 2]')
>>> interval.lower = 3
>>> interval
it will raise the RangeBoundsException:
intervals.exc.RangeBoundsException: Min value 3 is bigger than max value 2.